### PR TITLE
Improved external document references

### DIFF
--- a/common/core_external_doc_ref.xsl
+++ b/common/core_external_doc_ref.xsl
@@ -3,8 +3,8 @@
 	<xsl:import href="../common/core_utilities.xsl"/>
 	<!--
         * Copyright © 2008-2017 Enterprise Architecture Solutions Limited.
-	 	* This file is part of Essential Architecture Manager, 
-	 	* the Essential Architecture Meta Model and The Essential Project.
+        * This file is part of Essential Architecture Manager,
+        * the Essential Architecture Meta Model and The Essential Project.
         *
         * Essential Architecture Manager is free software: you can redistribute it and/or modify
         * it under the terms of the GNU General Public License as published by
@@ -18,10 +18,10 @@
         *
         * You should have received a copy of the GNU General Public License
         * along with Essential Architecture Manager.  If not, see <http://www.gnu.org/licenses/>.
-        * 
-    -->
+        *
+		-->
 	<!-- Receive an instance node and report any external repository references
-    that are defined against it in a table -->
+		that are defined against it in a table -->
 	<!-- 04.11.2008	JWC	Added to new report servlet -->
 
 	<xsl:variable name="imageSuffixes" select="('png', 'jpg', 'jpeg','jpg, jpeg', 'bmp', 'gif')"/>
@@ -29,6 +29,7 @@
 	<xsl:variable name="extRefLinkTypes" select="/node()/simple_instance[type='Document_File_Type']"/>
 	<xsl:variable name="imageExtRefLinkTypes" select="$extRefLinkTypes[functx:contains-any-of(own_slot_value[slot_reference = 'extension_mime_type']/value, $imageSuffixes)]"/>
 	<xsl:variable name="videoExtRefLinkTypes" select="$extRefLinkTypes[functx:contains-any-of(own_slot_value[slot_reference = 'extension_mime_type']/value, $videoSuffixes)]"/>
+	<xsl:variable name="extDocRefsInNewWindow" select="/node()/simple_instance[type = 'Report_Constant' and own_slot_value[slot_reference = 'report_constant_short_name']/value = 'extDocRefInNewWindow']/own_slot_value[slot_reference = 'report_constant_value']/value = 'yes'"/>
 
 	<xsl:template match="node()" mode="ReportExternalDocRef">
 		<xsl:param name="emptyMessage">
@@ -46,6 +47,7 @@
 						<xsl:variable name="anExternalReposInst" select="$anExternalDocRef/own_slot_value[slot_reference = 'external_reference_links']/value"/>
 						<li>
 							<a>
+								<xsl:if test="$extDocRefsInNewWindow = true()"><xsl:attribute name="target">_blank</xsl:attribute></xsl:if>
 								<xsl:attribute name="href">
 									<xsl:value-of select="$anExternalDocRef/own_slot_value[slot_reference = 'external_reference_url']/value"/>
 								</xsl:attribute>
@@ -73,7 +75,6 @@
 		</xsl:param>
 		<xsl:param name="extDocRefs" select="()"/>
 
-
 		<xsl:choose>
 			<xsl:when test="count($extDocRefs) > 0">
 				<!-- Create an image slider for image-based external documents -->
@@ -85,7 +86,7 @@
 					<script>
 						$(document).ready(function(){
 							$('.carousel').carousel({
-							  interval: false
+								interval: false
 							})
 						});
 					</script>
@@ -135,10 +136,10 @@
 							<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 							<span class="sr-only">Next</span>
 						</a>
-					</div>					
+					</div>
 				</xsl:if>
-				
-				<xsl:if test="count($videoDocRefs) > 0">		
+
+				<xsl:if test="count($videoDocRefs) > 0">
 					<h2>External Videos</h2>
 					<div id="videos">
 						<xsl:for-each select="$videoDocRefs">
@@ -166,7 +167,8 @@
 						<xsl:for-each select="$docRefList">
 							<xsl:variable name="anExternalDocRef" select="current()"/>
 							<li>
-								<a target="_blank">
+								<a>
+									<xsl:if test="$extDocRefsInNewWindow = true()"><xsl:attribute name="target">_blank</xsl:attribute></xsl:if>
 									<xsl:attribute name="href">
 										<xsl:value-of select="$anExternalDocRef/own_slot_value[slot_reference = 'external_reference_url']/value"/>
 									</xsl:attribute>
@@ -195,6 +197,7 @@
 		<xsl:param name="urlPrefix"/>
 
 		<a>
+			<xsl:if test="$extDocRefsInNewWindow = true()"><xsl:attribute name="target">_blank</xsl:attribute></xsl:if>
 			<xsl:attribute name="href">
 				<xsl:value-of select="$extDocRef/own_slot_value[slot_reference = 'external_reference_url']/value"/>
 			</xsl:attribute>

--- a/common/core_external_doc_ref.xsl
+++ b/common/core_external_doc_ref.xsl
@@ -66,6 +66,20 @@
 
 	</xsl:template>
 
+	<xsl:template name="renderDocRefListUL">
+    <xsl:param name="docRefList"/>
+    <xsl:param name="toNewWindow" select="true()"/>
+    <ul>
+      <xsl:for-each select="$docRefList">
+        <xsl:variable name="anExternalDocRef" select="current()"/>
+        <li>
+					<xsl:call-template name="RenderExternalDocRef">
+						<xsl:with-param name="extDocRef" select="current()"/>
+					</xsl:call-template>
+        </li>
+      </xsl:for-each>
+    </ul>
+  </xsl:template>
 
 	<!-- Receive a list of external doc references and display them as required -->
 	<!-- 26.09.2016	JP Created -->

--- a/enterprise/core_el_group_actor_summary.xsl
+++ b/enterprise/core_el_group_actor_summary.xsl
@@ -37,6 +37,7 @@
 	<xsl:include href="../common/core_header.xsl"/>
 	<xsl:include href="../common/core_footer.xsl"/>
 	<xsl:include href="../common/datatables_includes.xsl"/>
+	<xsl:include href="../common/core_external_doc_ref.xsl"/>
 
 	<!--<xsl:include href="../business/menus/core_product_type_menu.xsl" />-->
 
@@ -71,6 +72,7 @@
 	<xsl:variable name="allActor2RoleRelations" select="/node()/simple_instance[type = 'ACTOR_TO_ROLE_RELATION']"/>
 	<xsl:variable name="allA2RForActor" select="$allActor2RoleRelations[own_slot_value[slot_reference = 'act_to_role_from_actor']/value = $currentActor/name]"/>
 	<xsl:variable name="allRolesForActor" select="$allRoles[name = $allA2RForActor/own_slot_value[slot_reference = 'act_to_role_to_role']/value]"/>
+	<xsl:variable name="allExternalRefs" select="/node()/simple_instance[name = $currentActor/own_slot_value[slot_reference = 'external_reference_links']/value]"/>
 
 	<xsl:variable name="maxDepth" select="6"/>
 
@@ -451,6 +453,27 @@
 							</div>
 							<hr/>
 						</div>
+
+						<!--Setup SupportingDocs Section-->
+						<div class="col-xs-12">
+							<div class="sectionIcon">
+								<i class="fa fa-file-text-o icon-section icon-color"/>
+							</div>
+							<div>
+								<h2 class="text-primary">
+									<xsl:value-of select="eas:i18n('Supporting Documentation')"/>
+								</h2>
+							</div>
+							<div class="content-section">
+								<xsl:call-template name="RenderExternalDocRefList">
+									<xsl:with-param name="extDocRefs" select="$allExternalRefs"/>
+									<xsl:with-param name="emptyMessage">-</xsl:with-param>
+								</xsl:call-template>
+
+							</div>
+							<hr/>
+						</div>
+
 						<!--Setup Closing Tags-->
 					</div>
 				</div>


### PR DESCRIPTION
This request
- Groups External Documents by their classification ("Classified As slot") to aid rendering
- Adds a new Report Constant to always target links to a new window
- Moves rendering a doc ref list as a `<ul>` to a distinct template to allow any page to use it
- Adds external documents section to Group Actor Summary report
- Has lots of extraneous lines in the commits as tabs vs spaces are all over the place